### PR TITLE
get_data_section($name) should not die if there is no __DATA__ section.

### DIFF
--- a/lib/Data/Section/Simple.pm
+++ b/lib/Data/Section/Simple.pm
@@ -16,7 +16,9 @@ sub get_data_section {
     my $self = ref $_[0] ? shift : __PACKAGE__->new(scalar caller);
 
     if (@_) {
-        return $self->get_data_section->{$_[0]};
+        my $all = $self->get_data_section;
+        return unless $all;
+        return $all->{$_[0]};
     } else {
         my $d = do { no strict 'refs'; \*{$self->{package}."::DATA"} };
         return unless defined fileno $d;

--- a/t/no-datat.t
+++ b/t/no-datat.t
@@ -1,0 +1,7 @@
+use strict;
+use Data::Section::Simple qw(get_data_section);
+use Test::More;
+
+is get_data_section('foo.html'), undef, 'Do not die.';
+
+done_testing;


### PR DESCRIPTION
Current version dies with folllowing message.

```
Can't use an undefined value as a HASH reference at /Users/tokuhirom/.plenv/versions/5.16.3/lib/perl5/site_perl/5.16.3/Data/Section/Simple.pm line 19
```

It's not user friendly.
