### PR TITLE
Retrieve data correctly in a forked process

### DIFF
--- a/lib/Data/Section/Simple.pm
+++ b/lib/Data/Section/Simple.pm
@@ -20,7 +20,21 @@ sub get_data_section {
         return unless $all;
         return $all->{$_[0]};
     } else {
-        my $d = do { no strict 'refs'; \*{$self->{package}."::DATA"} };
+        my $filepath;
+        if ($self->{package} eq 'main') {
+            my $l = 0;
+            while (my @c = caller($l++)) {
+                $filepath = $c[1];
+            }
+        } else {
+            my $pkg = $self->{package};
+            $pkg =~ s/::/\//g;
+            $pkg .= '.pm';
+            $filepath = $INC{$pkg} if $INC{$pkg};
+        }
+        return unless $filepath;
+
+        open my $d, '<', $filepath or return;
         return unless defined fileno $d;
 
         seek $d, 0, 0;

--- a/t/multi-processes.t
+++ b/t/multi-processes.t
@@ -1,0 +1,45 @@
+use strict;
+use Data::Section::Simple qw(get_data_section);
+use Test::More;
+
+my $expect =<<HTML;
+<html>
+<body>Foo</body>
+</html>
+
+HTML
+
+my $n = 100;
+while ($n-- > 0) {
+    fork && next;
+    exit(get_data_section('foo.html') eq $expect ? 0 : 1);
+}
+
+my $failed = 0;
+while (waitpid(-1,0) > 0) {
+    $failed = 1 if $? >> 8 != 0;
+}
+
+ok(!$failed);
+
+done_testing;
+
+__DATA__
+
+@@ foo.html
+<html>
+<body>Foo</body>
+</html>
+
+@@ bar.tt  
+[% IF foo %]
+bar
+[% END %]
+
+__END__
+
+=head1 NAME
+
+basic.t
+
+=cut


### PR DESCRIPTION
The file handler (`\*{PACKAGE::DATA}`) points same address among a parent and child processes, so sometimes a child process fails to get data in following condition:

```
<child1>     <child2>
seek $d,0,0
             seek $d,0,0
<$d>
             <$d> # fail. position of $d is at end of file.
```

So explicitly open a target file and use this filehandle instead of `\*{PACKAGE::DATA}`.
